### PR TITLE
update jsch to version 0.1.55 to allow it to connect to existing raspberry pi installation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@
     <dependency>
       <groupId>com.jcraft</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.42</version>
+      <version>0.1.55</version>
     </dependency>
     <dependency>
 		<groupId>hsqldb</groupId>


### PR DESCRIPTION
Without this, security negations would fail.

Signed-off-by: Tzachi Dar <tzachi.dar@gmail.com>