### PR TITLE
Allow chainsaw to read a directory containing more than one file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,10 +390,10 @@
       <artifactId>xstream</artifactId>
       <version>1.1.2</version>
     </dependency>
-    <dependency>
-      <groupId>commons-vfs</groupId>
-      <artifactId>commons-vfs</artifactId>
-      <version>1.0</version>
+     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-vfs2</artifactId>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,11 @@
       <version>1.16.20</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+       <groupId>commons-io</groupId>
+       <artifactId>commons-io</artifactId>
+       <version>2.6</version>
+    </dependency>	
   </dependencies>
 
   <reporting>

--- a/src/main/java/org/apache/log4j/chainsaw/vfs/VFSLogFilePatternReceiver.java
+++ b/src/main/java/org/apache/log4j/chainsaw/vfs/VFSLogFilePatternReceiver.java
@@ -17,10 +17,10 @@
 package org.apache.log4j.chainsaw.vfs;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.vfs.*;
-import org.apache.commons.vfs.provider.URLFileName;
-import org.apache.commons.vfs.provider.sftp.SftpFileSystemConfigBuilder;
-import org.apache.commons.vfs.util.RandomAccessMode;
+import org.apache.commons.vfs2.*;
+import org.apache.commons.vfs2.provider.URLFileName;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+import org.apache.commons.vfs2.util.RandomAccessMode;
 import org.apache.log4j.chainsaw.receivers.VisualReceiver;
 import org.apache.log4j.varia.LogFilePatternReceiver;
 
@@ -369,6 +369,7 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
                 
                 try {
                     SftpFileSystemConfigBuilder.getInstance().setStrictHostKeyChecking(opts, "no");
+                    SftpFileSystemConfigBuilder.getInstance( ).setUserDirIsRoot(opts, false);
                 } catch (NoClassDefFoundError ncdfe) {
                     getLogger().warn("JSch not on classpath!", ncdfe);
                 }
@@ -410,6 +411,7 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
                     //if jsch not in classpath, can get NoClassDefFoundError here
                     try {
                         SftpFileSystemConfigBuilder.getInstance().setStrictHostKeyChecking(opts, "no");
+                        SftpFileSystemConfigBuilder.getInstance( ).setUserDirIsRoot(opts, false);
                     } catch (NoClassDefFoundError ncdfe) {
                         getLogger().warn("JSch not on classpath!", ncdfe);
                     }
@@ -462,6 +464,7 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
                         //if jsch not in classpath, can get NoClassDefFoundError here
                         try {
                             SftpFileSystemConfigBuilder.getInstance().setStrictHostKeyChecking(opts, "no");
+                            SftpFileSystemConfigBuilder.getInstance( ).setUserDirIsRoot(opts, false);
                         } catch (NoClassDefFoundError ncdfe) {
                             getLogger().warn("JSch not on classpath!", ncdfe);
                         }
@@ -470,7 +473,6 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
                         synchronized (fileSystemManager) {
                             if (fileObject != null) {
                                 fileObject.getFileSystem().getFileSystemManager().closeFileSystem(fileObject.getFileSystem());
-                                fileObject.close();
                                 fileObject = null;
                             }
 

--- a/src/main/java/org/apache/log4j/chainsaw/vfs/VFSLogFilePatternReceiver.java
+++ b/src/main/java/org/apache/log4j/chainsaw/vfs/VFSLogFilePatternReceiver.java
@@ -320,12 +320,18 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
         }
 
         public void run() {
+            ProcessSingleFile(getFileURL());
+        }
+
+        private void ProcessSingleFile(String fileUrl) {
+            Reader reader = null;
+            FileObject fileObject = null;
             //thread should end when we're no longer active
             while (reader == null && !terminated) {
-                int atIndex = getFileURL().indexOf("@");
-                int protocolIndex = getFileURL().indexOf("://");
+                int atIndex =fileUrl.indexOf("@");
+                int protocolIndex = fileUrl.indexOf("://");
 
-                String loggableFileURL = atIndex > -1 ? getFileURL().substring(0, protocolIndex + "://".length()) + "username:password" + getFileURL().substring(atIndex) : getFileURL();
+                String loggableFileURL = atIndex > -1 ? fileUrl.substring(0, protocolIndex + "://".length()) + "username:password" + fileUrl.substring(atIndex) :fileUrl;
                 getLogger().info("attempting to load file: " + loggableFileURL);
                 try {
                     FileSystemManager fileSystemManager = VFS.getManager();
@@ -338,7 +344,7 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
                     }
 
                     synchronized (fileSystemManager) {
-                        fileObject = fileSystemManager.resolveFile(getFileURL(), opts);
+                        fileObject = fileSystemManager.resolveFile(fileUrl, opts);
                         if (fileObject.exists()) {
                             reader = new InputStreamReader(fileObject.getContent().getInputStream(), "UTF-8");
                             //now that we have a reader, remove additional portions of the file url (sftp passwords, etc.)
@@ -397,7 +403,7 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
                                 fileObject = null;
                             }
 
-                            fileObject = fileSystemManager.resolveFile(getFileURL(), opts);
+                            fileObject = fileSystemManager.resolveFile(fileUrl, opts);
                         }
 
                         //file may not exist..
@@ -410,7 +416,7 @@ public class VFSLogFilePatternReceiver extends LogFilePatternReceiver implements
                                 getLogger().info(getPath() + " - unable to refresh fileobject", err);
                             }
 
-                            if (isGZip(getFileURL())) {
+                            if (isGZip(fileUrl)) {
                                 InputStream gzipStream = new GZIPInputStream(fileObject.getContent().getInputStream());
                                 Reader decoder = new InputStreamReader(gzipStream,  "UTF-8");
                                 BufferedReader bufferedReader = new BufferedReader(decoder);


### PR DESCRIPTION
On linux it is common to use logrotate to handle log files.

Logrotate trunks the files as they reach a certain size and also zips them.

Sometimes it is needed to open more than one file and show them on chainsaw.

An example to the content of such a directory is:

  pump-loop-date.log

  pump-loop-date.log.1

  pump-loop-date.log.2.gz

  pump-loop-date.log.3.gz 

The goal is pass the directory name and the files pattern.

For example:

sftp://user:pass@192.168.1.20:20022/var/log/openaps/pump-loop-date.log*

and have chainsaw show all matching files by their order.