### PR TITLE
column LINE location is not correct.

### DIFF
--- a/src/main/java/org/apache/log4j/chainsaw/ChainsawColumns.java
+++ b/src/main/java/org/apache/log4j/chainsaw/ChainsawColumns.java
@@ -43,8 +43,8 @@ public class ChainsawColumns {
         columnNames.add(ChainsawConstants.CLASS_COL_NAME);
         columnNames.add(ChainsawConstants.METHOD_COL_NAME);
         columnNames.add(ChainsawConstants.FILE_COL_NAME);
-        columnNames.add(ChainsawConstants.MILLIS_DELTA_COL_NAME_LOWERCASE.toUpperCase()); //add uppercase col name
         columnNames.add(ChainsawConstants.LINE_COL_NAME);
+        columnNames.add(ChainsawConstants.MILLIS_DELTA_COL_NAME_LOWERCASE.toUpperCase()); //add uppercase col name
 
         //NOTE:  ID must ALWAYS be last field because the model adds this value itself as an identifier to the end of the consructed vector
         columnNames.add(ChainsawConstants.ID_COL_NAME);


### PR DESCRIPTION
When adding columnName, LINE is after MILLIS_DELTA:
``` java
    columnNames.add(ChainsawConstants.CLASS_COL_NAME);
    columnNames.add(ChainsawConstants.METHOD_COL_NAME);
    columnNames.add(ChainsawConstants.FILE_COL_NAME);
    columnNames.add(ChainsawConstants.MILLIS_DELTA_COL_NAME_LOWERCASE.toUpperCase()); //add uppercase col name
    columnNames.add(ChainsawConstants.LINE_COL_NAME);
````

But, in indexes, LINE is before MILLIS_DELTA:

``` java
  public static final int INDEX_METHOD_COL_NAME = 10;
  public static final int INDEX_FILE_COL_NAME = 11;
  public static final int INDEX_LINE_COL_NAME = 12;
  public static final int INDEX_MILLIS_DELTA_COL_NAME = 13;
```

It makes the LINE and MILLIS_DELTA can't show correctly.