### PR TITLE
Disable OSX integration on anything that is not OSX

### DIFF
--- a/src/main/java/org/apache/log4j/chainsaw/osx/OSXIntegration.java
+++ b/src/main/java/org/apache/log4j/chainsaw/osx/OSXIntegration.java
@@ -34,23 +34,28 @@ public class OSXIntegration {
     private static final Desktop desktop = Desktop.getDesktop();
 
     public static final void init(final LogUI logUI) {
-        if( !IS_OSX ) return;
-        
-        desktop.setAboutHandler(e ->
-            logUI.showAboutBox()
-        );
+        if( desktop.isSupported(Desktop.Action.APP_ABOUT) ){
+            desktop.setAboutHandler(e ->
+                logUI.showAboutBox()
+            );
+        }
 
-        desktop.setPreferencesHandler(e ->
-            logUI.showApplicationPreferences()
-        );
-        desktop.setQuitHandler((e, r) -> {
-                if (
-                    logUI.exit()) {
-                    r.performQuit();
-                } else {
-                    r.cancelQuit();
+        if( desktop.isSupported(Desktop.Action.APP_PREFERENCES) ){
+            desktop.setPreferencesHandler(e ->
+                logUI.showApplicationPreferences()
+            );
+        }
+
+        if( desktop.isSupported(Desktop.Action.APP_QUIT_HANDLER) ){
+            desktop.setQuitHandler((e, r) -> {
+                    if (
+                        logUI.exit()) {
+                        r.performQuit();
+                    } else {
+                        r.cancelQuit();
+                    }
                 }
-            }
-        );
+            );
+        }
     }
 }

--- a/src/main/java/org/apache/log4j/chainsaw/osx/OSXIntegration.java
+++ b/src/main/java/org/apache/log4j/chainsaw/osx/OSXIntegration.java
@@ -34,6 +34,8 @@ public class OSXIntegration {
     private static final Desktop desktop = Desktop.getDesktop();
 
     public static final void init(final LogUI logUI) {
+        if( !IS_OSX ) return;
+        
         desktop.setAboutHandler(e ->
             logUI.showAboutBox()
         );


### PR DESCRIPTION
Chainsaw crashes on Linux(Debian 10, GNOME) when the OSX integration code runs.  Simply check to see if we are on OSX before initializing.