### PR TITLE
Docs: fixed wrong build command

### DIFF
--- a/HOWTOBUILD.txt
+++ b/HOWTOBUILD.txt
@@ -26,7 +26,7 @@ http://maven.apache.org
 * cd to Chainsaw project checkout directory
 
 	mvn site:site
-	mvn install
+	mvn install -P packaging
 
 This will automatically build and assemble the Chainsaw distribution which includes a .sh & .bat shell script to run Chainsaw.  You can then run Chainsaw as follows:
 


### PR DESCRIPTION
`HOWTOBUILD.txt` contains info about distribution files and command lines to build and get it. But it doesn't work -- assembly disabled by default.

Project's pom file uses packaging profile now, so it's ignored on default maven build -- you must enable it manually. There are many options:
- activate by command line: `mvn install -P packaging`
- activate by `<activeByDefault>` settings:
![shot_230312_225830](https://user-images.githubusercontent.com/8344157/224566537-34be5a97-88c1-4efd-929e-e1f955d8b1a4.png)
- [many other use cases](https://maven.apache.org/guides/introduction/introduction-to-profiles.html#how-can-a-profile-be-triggered-how-does-this-vary-according-to-t).

So that PR fixes documentation with correct command lines.